### PR TITLE
adding conda, __init__ for module resolution

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,33 @@
+name: crypto_keeper
+channels:
+  - conda-forge
+dependencies:
+ - python-dotenv
+ - aiodns
+ - aiohttp
+ - async-timeout
+ - attrs
+ - certifi
+ - cffi
+ - chardet
+ - cryptography
+ - idna
+ - multidict
+ - numpy
+ - pandas
+ - pycares
+ - pycparser
+ - pyotp
+ - python-dateutil
+ - python-dotenv
+ - pytz
+ - requests
+ - six
+ - typing-extensions
+ - urllib3
+ - yarl
+ - pip
+ - pip:
+   - int-date
+   - ccxt
+   - stockstats

--- a/src/account.py
+++ b/src/account.py
@@ -1,5 +1,5 @@
-from src.ftx_client import ftx_client
-from src.coin_balance import CoinBalance
+from .ftx_client import ftx_client
+from .coin_balance import CoinBalance
 
 def get_balances():
     balances_data = ftx_client.fetch_balance()


### PR DESCRIPTION
PR to add Conda to env as well as cleaning up module resolution. Thanks to __init__.py you don't have to `.src.<module>` you should be able to just import from `.<module>` from within the `src` folder. 